### PR TITLE
fix: Wiki-sync repo referene

### DIFF
--- a/.github/workflows/platform.wiki-sync.yml
+++ b/.github/workflows/platform.wiki-sync.yml
@@ -38,7 +38,7 @@ jobs:
           repository: ${{ env.wiki_target_repo }}
           path: ${{ env.wiki_target_repo }}
           token: '${{ secrets.PLATFORM_REPO_UPDATE_PAT }}' # Sets general GIT credentials up
-          ref: main
+          ref: master
 
       - name: Configure Local Git
         run: |

--- a/.github/workflows/platform.wiki-sync.yml
+++ b/.github/workflows/platform.wiki-sync.yml
@@ -38,6 +38,7 @@ jobs:
           repository: ${{ env.wiki_target_repo }}
           path: ${{ env.wiki_target_repo }}
           token: '${{ secrets.PLATFORM_REPO_UPDATE_PAT }}' # Sets general GIT credentials up
+          ref: main
 
       - name: Configure Local Git
         run: |


### PR DESCRIPTION
- Added explitit reference of `master` branch for wiki as automated default fetch did not work