### PR TITLE
fix: Removed emoji icon from metadata as it conflicted with the bicep build conversion to a hashtable

### DIFF
--- a/constructs/azureImageBuilder/templates/image.deploy.bicep
+++ b/constructs/azureImageBuilder/templates/image.deploy.bicep
@@ -65,7 +65,7 @@ param virtualNetworkDeploymentScriptSubnetAddressPrefix string = cidrSubnet(virt
 @description('Optional. The name of the Deployment Script to trigger the Image Template baking.')
 param storageDeploymentScriptName string = 'ds-triggerUpload-storage'
 
-@description('Optional. The files to upload to the Assets Storage Account. Note, the file you\'re uploading should not contain emojis (🍔) as they may cause problems when loaded into the environment of the uploading deployment script.')
+@description('Optional. The files to upload to the Assets Storage Account. Note, the file you\'re uploading should not contain emojis as they may cause problems when loaded into the environment of the uploading deployment script.')
 param storageAccountFilesToUpload storageAccountFilesToUploadType[]?
 
 @description('Optional. The name of the Deployment Script to trigger the image tempalte baking.')
@@ -113,7 +113,7 @@ param deploymentsToPerform string = 'Only assets & image'
 // Deployments //
 // =========== //
 
-module imageConstruct 'br/public:avm/ptn/virtual-machine-images/azure-image-builder:0.2.1' = {
+module imageConstruct 'br/public:avm/ptn/virtual-machine-images/azure-image-builder:0.2.2' = {
   name: '${uniqueString(deployment().name, resourceLocation)}-image-construct'
   params: {
     deploymentsToPerform: deploymentsToPerform


### PR DESCRIPTION
# Change

- Updated to latest ptn version
- Updated template metadata in param file

Original error
```pwsh
Get-TemplateParameterValue -TemplateFilePath 'C:\sbx.image.linux.bicep' -ParameterName 'resourceGroupNAme'
ERROR: The command failed with an unexpected error. Here is the traceback:
ERROR: 'charmap' codec can't encode character '\U0001f354' in position 45041: character maps to <undefined>
Traceback (most recent call last):
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\knack/cli.py", line 233, in invoke
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 663, in execute
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 726, in _run_jobs_serially
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 697, in _run_job
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 333, in __call__
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/command_operation.py", line 121, in handler
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/resource/custom.py", line 3745, in build_bicep_file
  File "encodings\cp1252.py", line 19, in encode
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f354' in position 45041: character maps to <undefined>
To check existing issues, please visit: https://github.com/Azure/azure-cli/issues
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
